### PR TITLE
set explicit padding-left: 0 to .nav-list

### DIFF
--- a/src/components/Sidebar-menu-akahon.vue
+++ b/src/components/Sidebar-menu-akahon.vue
@@ -454,6 +454,7 @@
   }
   .sidebar .nav-list {
     margin-top: 20px;
+    padding-left: 0;
     /* margin-bottom: 60px; */
     /* height: 100%; */
     /* min-height: min-content; */


### PR DESCRIPTION
When using Bootstrap, bootstrap.css has ol, ul { padding-left: 2rem; }
Thats why .nav-list is shifted a little and causing visual issues when collapsing the sidebar.

This is what happened when you worked with Bootstrap. However, without Bootstrap, this change does not affect the behavior/visual of the sidebar.

![Bildschirmvideo aufnehmen 2023-05-12 um 20 50 51](https://github.com/akahon/vue-sidebar-menu-akahon/assets/38540719/6247c56d-324f-406e-b673-f738a46e80e1)